### PR TITLE
fix typo and docker package name

### DIFF
--- a/en_US/installation/docker.md
+++ b/en_US/installation/docker.md
@@ -20,9 +20,8 @@ yum install docker
 -   made of ``deb``
 
 ````
-apt-gand update
-apt-gand install docker
-apt-gand install docker.io
+apt-get update
+apt-get install docker.io
 ````
 
 ## Installing a Jeedom image

--- a/fr_FR/installation/docker.md
+++ b/fr_FR/installation/docker.md
@@ -21,7 +21,6 @@ yum install docker
 
 ````
 apt-get update
-apt-get install docker
 apt-get install docker.io
 ````
 


### PR DESCRIPTION
The docker package as nothing to do with docker containers in debian/ubuntu :
https://packages.debian.org/search?keywords=docker