### PR TITLE
remplacement

### DIFF
--- a/fr_FR/howtoadvance/letsencrypt.mise_en_place.md
+++ b/fr_FR/howtoadvance/letsencrypt.mise_en_place.md
@@ -96,7 +96,7 @@ C’est quand même mieux quand c’est automatique. Pour ce faire, voici les é
 -   Créez un fichier pour y écrire le script (son emplacement est libre) : ``nano /bin/certletsencryptrenew.sh``
 -   Saisissez les lignes ci-dessous dans le fichier créé précédemment. Le copier/coller fonctionne via putty. Ce script vérifie l’expiration du certificat et le renouvelle automatiquement si la date d’expiration est à moins de 30 jours. Vous devez remplacer le paramètre domaine.com par votre valeur :
 ````
-    curl -L -o /usr/local/sbin/le-renew http://do.co/le-renew
+    curl -L -o /usr/local/sbin/le-renew https://raw.githubusercontent.com/frixo3190/le-renew/main/le-renew
     chmod +x /usr/local/sbin/le-renew
     le-renew domaine.com
 ````


### PR DESCRIPTION
Remplacement de la source du script "le-renew" http://do.co/le-renew par https://raw.githubusercontent.com/frixo3190/le-renew/main/le-renew
car le script initial bug comme remonté par de  multiple utilisateurs dans la community

en effet la fonction "get_domain_list" dans la ligne du script renvoie ... vide , du coup on a un message d'erreur 
"$le_path"/letsencrypt-auto certonly --apache --renew-by-default --domains "${domain_list}"

la version corrigée change cette ligne par 
"$le_path"/letsencrypt-auto certonly --apache --renew-by-default -d $domain

ce qui permet au script de bien avoir le nom de domaine saisie en paramètre et donc de bien géré le renouvellement auto

cdt