### PR TITLE
doc: add requireOsVersion key in plugin_info

### DIFF
--- a/fr_FR/dev/structure_info_json.md
+++ b/fr_FR/dev/structure_info_json.md
@@ -17,6 +17,7 @@ Champs                   | Valeurs                                              
 ``licence`` *                | Type de licence.                                                                                                          |
 ``author`` *                 | Nom de l’auteur du plugin, tel qu’il sera affiché une fois le plugin installé, dans les informations de celui-ci.         |
 ``require`` *                | Version minimum requise de Jeedom (Core).                                                                                                |
+``requireOsVersion``                 | Version minimum requise de Debian pour activer le plugin.(Core 4.4.4 minimum)                                                                                               |
 ``category`` *               | Catégorie de classement du plugin sur le Market jeedom. **Respecter impérativement la [nomenclature du tableau ci-dessous](https://doc.jeedom.com/fr_FR/dev/structure_info_json/#NOMENCLATURE%20CATEGORIES)** |
 ``display``                  | Si le plugin utilise un panel dédié sur le desktop,. Il s’agit du nom du fichier principal de ce panel.                    |
 ``mobile``                   | Si le plugin utilise un panel dédié sur la webApp Jeedom. Il s’agit du nom du fichier principal de ce panel.   |


### PR DESCRIPTION
<!--
  Thanks for your contribution to make Jeedom better!

  Read contribute documentation before proposing PR.
  Documentation involve several automated processed and not all documentation can be edited here.
  Plugins needs PR on the plugin repository.
  Core documentation PR must apply on Core repository.
-->


## Documentation

[contribute](https://doc.jeedom.com/en_US/contribute/)

<!--
  Some useful links for contributors
-->
[beta-testing](https://doc.jeedom.com/en_US/beta/)
[community](https://community.jeedom.com/)
[plugins](https://doc.jeedom.com/en_US/dev/)
