### PR TITLE
Update link to developer documentation

### DIFF
--- a/fr_FR/dev/publication_plugin.md
+++ b/fr_FR/dev/publication_plugin.md
@@ -2,7 +2,7 @@
 
 ## Pré-requis
 
-- S’être inscrit en tant que dev, voir [ici](https://www.jeedom.com/site/fr/dev.html).
+- S’être inscrit en tant que dev, voir [ici](https://doc.jeedom.com/fr_FR/dev/).
 - Avoir attendu la validation du compte market comme développeur.
 - Vérifier sur Community que vous avez accès à "Salon des développeurs".
 - Avoir mis votre plugin sur github (dépôt privé ou non).


### PR DESCRIPTION
## Description
Un lien ne fonctionne pas sur la page https://doc.jeedom.com/fr_FR/dev/publication_plugin 

### Suggested changelog entry
Modification du lien vers la documentation développeur

### Related issues/external references

## Types of changes
- [ ] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [X] Documentation improvement

## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have checked there is no other PR open for the same change.
- [X] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [X] I grant the project the right to include and distribute the code under the GNU.
- [X] I have added tests to cover my changes.
- [X] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.
